### PR TITLE
Removed "array" as a primitive type

### DIFF
--- a/src/ClassGeneration/Argument.php
+++ b/src/ClassGeneration/Argument.php
@@ -55,7 +55,6 @@ class Argument extends ElementAbstract implements ArgumentInterface
      * @var array
      */
     protected $primitiveTypes = array(
-        'array',
         'bool', 'boolean',
         'decimal', 'double',
         'float',


### PR DESCRIPTION
With "array" set in the $primitiveTypes property you couldn't specify that an argument is type hinted as an array, for example:

public function foo(array $bar) { ... }